### PR TITLE
Sync capture to time

### DIFF
--- a/capture_Atik.py
+++ b/capture_Atik.py
@@ -63,6 +63,7 @@ def capture_images(temp_folder, camera):
                 current_temperature = "Unknown"
 
             # Save the image with metadata
+            timestamp = current_time.strftime("%Y%m%d-%H%M%S")
             image_path = os.path.join(temp_folder, f"MISS2-{timestamp}.png")
 
             metadata = PngImagePlugin.PngInfo()


### PR DESCRIPTION
Synchronise the capture start to time:
- Image captures are carried out at known times
- The date and time in the filename corresponds to the start of the exposure
- Given a date and time of interest, it is possible to construct a full filename to data (rather than listing files and searching for closest match)

Removed pixel value scaling, which allows for direct comparison of pixel intensities between images.